### PR TITLE
Adicionado tag para não limitar o resultado

### DIFF
--- a/CreateCSharpModelFromTable.sql
+++ b/CreateCSharpModelFromTable.sql
@@ -56,4 +56,4 @@ order by ColumnId
 set @Result = @Result  + '
 }'
 
-print @Result
+print CAST(@Result AS NTEXT)

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ order by ColumnId
 set @Result = @Result  + '
 }'
 
-print @Result
+print CAST(@Result AS NTEXT)
 ```
 ### Confira o resultado da execução do script
 


### PR DESCRIPTION
Em tabelas com muitas colunas, o "print" limitava o resultado, não trazendo todos os campos.